### PR TITLE
Ash fuel conditional on ash source

### DIFF
--- a/src/nurgling/actions/bots/BlockAshAction.java
+++ b/src/nurgling/actions/bots/BlockAshAction.java
@@ -52,7 +52,7 @@ public class BlockAshAction implements Action {
                 cand.cap = "Kiln";
                 cand.initattr(Container.Space.class);
                 cand.initattr(Container.FuelLvl.class);
-                cand.getattr(Container.FuelLvl.class).setMaxlvl(8);
+                cand.getattr(Container.FuelLvl.class).setMaxlvl(isBoard ? 3 : 8);
                 cand.getattr(Container.FuelLvl.class).setFueltype("Branch");
                 cand.initattr(Container.Tetris.class);
                 Container.Tetris tetris = cand.getattr(Container.Tetris.class);


### PR DESCRIPTION
We already have access to isBoard so why not use it to avoid making the bot more than 2x inefficient than it needs to be for boards, and this way it doesn't negatively impact blocks usage either.