### PR TITLE
Add WaitForFirstBurnout to make lye fix water outages as they happen

### DIFF
--- a/src/nurgling/actions/bots/LyeBoiler.java
+++ b/src/nurgling/actions/bots/LyeBoiler.java
@@ -7,7 +7,7 @@ import nurgling.NGameUI;
 import nurgling.NUtils;
 import nurgling.actions.*;
 import nurgling.areas.NArea;
-import nurgling.tasks.WaitForBurnout;
+import nurgling.tasks.WaitForFirstBurnout;
 import nurgling.tools.Container;
 import nurgling.tools.Context;
 import nurgling.tools.Finder;
@@ -73,7 +73,7 @@ public class LyeBoiler implements Action {
 
 
             while (res == null || res.IsSuccess()) {
-                NUtils.getUI().core.addTask(new WaitForBurnout(lighted, 8));
+                NUtils.getUI().core.addTask(new WaitForFirstBurnout(lighted, 12));
                 synchronized (NUtils.getGameUI()) {
                     new FreeContainers(containers, new NAlias("Lye")).run(gui);
                     res = new FillContainersFromAreas(containers, new NAlias("Ashes"), icontext).run(gui);

--- a/src/nurgling/tasks/WaitForBurnout.java
+++ b/src/nurgling/tasks/WaitForBurnout.java
@@ -1,17 +1,13 @@
 package nurgling.tasks;
 
-import haven.GItem;
 import haven.Gob;
-import haven.WItem;
-import haven.Widget;
-import nurgling.NGItem;
-import nurgling.NISBox;
-import nurgling.NInventory;
-import nurgling.tools.NAlias;
-import nurgling.tools.NParser;
 
 import java.util.ArrayList;
 
+/*
+ * Waits until ALL of the gobs in the list have a set of attributes which diverges from ALL of the flags passed as a mask
+ * Typically used to wait until a group of utilities have all finished burning through their respective tasks before setting them all up again together
+ */
 public class WaitForBurnout extends NTask
 {
     ArrayList<Gob> gobs;

--- a/src/nurgling/tasks/WaitForFirstBurnout.java
+++ b/src/nurgling/tasks/WaitForFirstBurnout.java
@@ -1,0 +1,37 @@
+package nurgling.tasks;
+
+import haven.Gob;
+
+import java.util.ArrayList;
+
+/*
+ * Waits until ANY of the gobs in the list has a set of attributes which diverges from ANY of the flags passed as a mask
+ * This is useful for waiting for the first gob which is not active across all of multiple possible flags
+ * e.g. waiting until some cauldron is either not burning or not full of water so it can be addressed without waiting for all of them to be out of both fuel and water
+ * Contrast with WaitForBurnout which waits for all gobs to not match all of the passed flags
+ */
+
+public class WaitForFirstBurnout extends NTask
+{
+    ArrayList<Gob> gobs;
+    int flame_flag;
+
+    public WaitForFirstBurnout(ArrayList<Gob> gobs, int flag)
+    {
+        this.gobs = gobs;
+        this.flame_flag = flag;
+    }
+
+    @Override
+    public boolean check()
+    {
+        for (Gob gob: gobs)
+        {
+            if((gob.ngob.getModelAttribute() & flame_flag) != flame_flag)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Adjust the waiting task from:
```Wait until ALL cauldrons burn out, then redo refill loop```
to instead:
```Wait until ANY cauldron burns out OR runs out of water, then redo refill loop```

That way it's not as important to refill all the cauldrons at the beginning as the bot will keep on top of it and keep refilling cauldrons as needed.