### PR TITLE
fix/ca initialization in NPFMap

### DIFF
--- a/src/nurgling/pf/NPFMap.java
+++ b/src/nurgling/pf/NPFMap.java
@@ -39,14 +39,7 @@ public class NPFMap
     public CellsArray addGob(Gob gob) {
         CellsArray ca;
 
-        if(gatesAlwaysClosed && isGate(gob)) {
-            ca = gob.ngob.getTrueCA();
-        } else {
-            ca = gob.ngob.getCA();
-        }
-//        ca = gob.ngob.getCA();
-
-        if (gob.ngob != null && gob.ngob.hitBox != null && ca != null && NUtils.player() != null && gob.id != NUtils.player().id && gob.getattr(Following.class) == null) {
+        if (gob.ngob != null && gob.ngob.hitBox != null && (ca = getCa(gob)) != null && NUtils.player() != null && gob.id != NUtils.player().id && gob.getattr(Following.class) == null) {
             CellsArray old = new CellsArray(ca.x_len, ca.y_len);
             old.begin = ca.begin;
             old.end = ca.end;
@@ -405,6 +398,14 @@ public class NPFMap
 
             }, new Coord(UI.scale(100), UI.scale(100)));
             NUtils.getUI().bind(wnd, 7002);
+        }
+    }
+
+    private CellsArray getCa(Gob gob) {
+        if(gatesAlwaysClosed && isGate(gob)) {
+            return gob.ngob.getTrueCA();
+        } else {
+            return gob.ngob.getCA();
         }
     }
 }


### PR DESCRIPTION
Exception in thread "nords2" java.lang.NullPointerException: Cannot read field "begin" because "hb" is null
    at nurgling.pf.CellsArray.<init>(CellsArray.java:26)
    at nurgling.pf.CellsArray.<init>(CellsArray.java:15)
    at nurgling.NGob.getCA(NGob.java:261)
    at nurgling.pf.NPFMap.addGob(NPFMap.java:45)
    at nurgling.pf.NPFMap.build(NPFMap.java:283)
    at nurgling.actions.PathFinder.construct(PathFinder.java:136)
    at nurgling.actions.PathFinder.construct(PathFinder.java:115)
    at nurgling.actions.PathFinder.run(PathFinder.java:73)
    at nurgling.actions.TakeItems.takeFromBarter(TakeItems.java:54)
    at nurgling.actions.TakeItems.run(TakeItems.java:36)
    at nurgling.actions.bots.FillJarWithVeges.run(FillJarWithVeges.java:43)
    at nurgling.widgets.NBotsMenu$NButton$4.run(NBotsMenu.java:384)
    at java.base/java.lang.Thread.run(Thread.java:1583)