### PR TITLE
Fix Eater bot: migrate to global-zone navigation

### DIFF
--- a/src/nurgling/actions/FindAndEatItems.java
+++ b/src/nurgling/actions/FindAndEatItems.java
@@ -34,34 +34,33 @@ public class FindAndEatItems implements Action
            cnt.addInItem(item, null);
         }
 
-//        for(String item: items) {
-//            for (Context.Input input : cnt.getInputs(item)) {
-//                if (input instanceof Context.InputPile) {
-//                    takeFromPile(gui, (Context.InputPile) input);
-//                } else if (input instanceof Context.InputContainer) {
-//                    takeFromContainer(gui, (Context.InputContainer) input);
-//                }
-//                if(!calcCalories())
-//                    break;
-//            }
-//            if(!calcCalories())
-//                break;
-//        }
+        if (area != null) {
+            for (Gob pile : Finder.findGobs(area, new NAlias("stockpile"))) {
+                if (!calcCalories())
+                    break;
+                takeFromPile(gui, pile);
+            }
+            for (Gob contgob : Finder.findGobs(area, new NAlias(new ArrayList<>(NContext.contcaps.keySet()), new ArrayList<>()))) {
+                if (!calcCalories())
+                    break;
+                takeFromContainer(gui, contgob);
+            }
+        }
         eatAll(gui);
         return Results.SUCCESS();
     }
 
-    public Results takeFromPile(NGameUI gui, Context.InputPile pile) throws InterruptedException
+    public Results takeFromPile(NGameUI gui, Gob pile) throws InterruptedException
     {
-        new PathFinder(pile.pile).run(gui);
-        new OpenTargetContainer("Stockpile",  pile.pile).run(gui);
+        new PathFinder(pile).run(gui);
+        new OpenTargetContainer("Stockpile",  pile).run(gui);
         while (calcCalories()) {
             if(gui.getInventory().getNumberFreeCoord(new Coord(1,1))==0)
             {
                 eatAll(gui);
             }
             TakeItemsFromPile tifp;
-            (tifp = new TakeItemsFromPile(pile.pile, gui.getStockpile(), 1)).run(gui);
+            (tifp = new TakeItemsFromPile(pile, gui.getStockpile(), 1)).run(gui);
             if(tifp.getResult() == 0)
                 break;
         }
@@ -69,9 +68,10 @@ public class FindAndEatItems implements Action
         return Results.SUCCESS();
     }
 
-    public Results takeFromContainer(NGameUI gui, Container cont) throws InterruptedException
+    public Results takeFromContainer(NGameUI gui, Gob contgob) throws InterruptedException
     {
-        new PathFinder(Finder.findGob(cont.gobid)).run(gui);
+        Container cont = new Container(contgob, NContext.contcaps.get(contgob.ngob.name), null);
+        new PathFinder(contgob).run(gui);
         new OpenTargetContainer(cont).run(gui);
         while (calcCalories()) {
             if(gui.getInventory().getNumberFreeCoord(new Coord(1,1))==0)
@@ -86,7 +86,7 @@ public class FindAndEatItems implements Action
             gui.ui.core.addTask(new WaitItems(NUtils.getGameUI().getInventory(), new NAlias(items), oldSize + 1));
         }
 
-        new CloseTargetWindow(NUtils.getGameUI().getWindow("Stockpile")).run(gui);
+        new CloseTargetContainer(cont).run(gui);
         return Results.SUCCESS();
     }
 

--- a/src/nurgling/actions/bots/Eater.java
+++ b/src/nurgling/actions/bots/Eater.java
@@ -30,22 +30,23 @@ public class Eater implements Action {
     public Results run(NGameUI gui) throws InterruptedException {
         ArrayList<String> items = FoodContainer.getFoodNames();
 
-        Pair<Coord2d,Coord2d> area = null;
+        // First try local area
         NArea nArea = NContext.findSpec(Specialisation.SpecName.eat.toString());
-        if(nArea==null)
-        {
+        if (nArea == null) {
+            // Try global area
             nArea = NContext.findSpecGlobal(Specialisation.SpecName.eat.toString());
         }
-        else
-        {
-            area = nArea.getRCArea();
-        }
-        if(area!=null) {
-            NContext cnt = new NContext(gui);
-            new FindAndEatItems(cnt, items, 8000, area).run(gui);
-            return NUtils.getEnergy()*10000>8000?Results.SUCCESS():Results.FAIL();
-        }
-        else
+
+        if (nArea == null) {
             return Results.FAIL();
+        }
+
+        // Navigate to the area using chunk navigation
+        NUtils.navigateToArea(nArea);
+        Pair<Coord2d,Coord2d> area = nArea.getRCArea();
+
+        NContext cnt = new NContext(gui);
+        new FindAndEatItems(cnt, items, 8000, area).run(gui);
+        return NUtils.getEnergy()*10000>8000?Results.SUCCESS():Results.FAIL();
     }
 }


### PR DESCRIPTION
## Summary
- The Eater bot (`eater` / "Eating bot") never called `NUtils.navigateToArea(...)`, so it only worked if the player already happened to be standing in a same-map "eat" area. It also had a missing assignment on the `findSpecGlobal` fallback branch, so `area` stayed `null` whenever no local eat area existed — meaning it could never actually use a cross-map/global eat zone at all, and would just silently fail.
- Brought `Eater.java` in line with the existing `FillWaterskinsGlobal` "Global Zone" pattern: try `NContext.findSpec` (local), fall back to `NContext.findSpecGlobal` (cross-map), then unconditionally call `NUtils.navigateToArea(nArea)` before deriving the RC bounds.
- Also re-enabled `FindAndEatItems`' pile/container food-fetching logic, which had been commented out in `07da5f13e` ("Eater disabled fix for Fishing") — that commit switched `Eater`/`FindAndEatItems` from the deprecated `Context` class to `NContext`, but `NContext` has no equivalent for `Context.getInputs()` / `InputPile` / `InputContainer`, so the fetch logic was disabled rather than ported. Ported it to the modern `Container` class (`nurgling.tools.Container`) + `Finder.findGobs(area, ...)` instead, so the bot now actually pulls food from stockpiles/containers in the eat zone instead of only eating whatever's already in inventory.

## Test plan
- [x] Confirmed in-game: Eater now navigates to and eats from an "eat"-specialization zone using the new chunk-navigation system, including pulling food out of a stockpile/container in that zone.
- [x] `ant hafen-client` compiles clean (`BUILD SUCCESSFUL`).